### PR TITLE
Allow for serializing to indented json

### DIFF
--- a/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -49,6 +49,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="test.json" />
+    <None Include="test_indented.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Json\Cake.Json.csproj">

--- a/Cake.Json.Tests/Test.cs
+++ b/Cake.Json.Tests/Test.cs
@@ -10,6 +10,37 @@ namespace Cake.Json.Tests
         FakeCakeContext context;
 
         const string SERIALIZED_JSON =  @"{""Name"":""Testing"",""Items"":[""One"",""Two"",""Three""],""KeysAndValues"":{""Key"":""Value"",""AnotherKey"":""AnotherValue"",""Such"":""Wow""},""Nested"":{""Id"":0,""Value"":7.3},""Multiples"":[{""Id"":1,""Value"":14.6},{""Id"":2,""Value"":29.2},{""Id"":3,""Value"":58.4}]}";
+        const string SERIALIZED_JSON_INDENTED = @"{
+  ""Name"": ""Testing"",
+  ""Items"": [
+    ""One"",
+    ""Two"",
+    ""Three""
+  ],
+  ""KeysAndValues"": {
+    ""Key"": ""Value"",
+    ""AnotherKey"": ""AnotherValue"",
+    ""Such"": ""Wow""
+  },
+  ""Nested"": {
+    ""Id"": 0,
+    ""Value"": 7.3
+  },
+  ""Multiples"": [
+    {
+      ""Id"": 1,
+      ""Value"": 14.6
+    },
+    {
+      ""Id"": 2,
+      ""Value"": 29.2
+    },
+    {
+      ""Id"": 3,
+      ""Value"": 58.4
+    }
+  ]
+}";
 
         [SetUp]
         public void Setup ()
@@ -32,6 +63,28 @@ namespace Cake.Json.Tests
 
             Assert.IsNotEmpty (json);
             Assert.AreEqual (SERIALIZED_JSON, json);
+        }
+
+        [Test]
+        public void SerializeToSTringWithNoIndentation()
+        {
+            var obj = new TestObject();
+
+            var json = context.CakeContext.SerializeJson (obj, Formatting.None);
+
+            Assert.IsNotEmpty (json);
+            Assert.AreEqual (SERIALIZED_JSON, json);
+        }
+
+        [Test]
+        public void SerializeToStringWithIndentation()
+        {
+            var obj = new TestObject();
+
+            var json = context.CakeContext.SerializeJson (obj, Formatting.Indented);
+
+            Assert.IsNotEmpty (json);
+            Assert.AreEqual (SERIALIZED_JSON_INDENTED, json);
         }
 
         [Test]

--- a/Cake.Json.Tests/Test.cs
+++ b/Cake.Json.Tests/Test.cs
@@ -68,7 +68,7 @@ namespace Cake.Json.Tests
         [Test]
         public void SerializeToSTringWithNoIndentation()
         {
-            var obj = new TestObject();
+            var obj = new TestObject ();
 
             var json = context.CakeContext.SerializeJson (obj, Formatting.None);
 
@@ -79,7 +79,7 @@ namespace Cake.Json.Tests
         [Test]
         public void SerializeToStringWithIndentation()
         {
-            var obj = new TestObject();
+            var obj = new TestObject ();
 
             var json = context.CakeContext.SerializeJson (obj, Formatting.Indented);
 
@@ -100,6 +100,36 @@ namespace Cake.Json.Tests
 
             Assert.IsNotEmpty (json);
             Assert.AreEqual (SERIALIZED_JSON, json);
+        }
+
+        [Test]
+        public void SerializeToFileWithNoIndentation()
+        {
+            var obj = new TestObject ();
+
+            var file = new FilePath ("./serialized.json");
+
+            context.CakeContext.SerializeJsonToFile (file, obj, Formatting.None);
+
+            var json = System.IO.File.ReadAllText (file.MakeAbsolute (context.CakeContext.Environment).FullPath);
+
+            Assert.IsNotEmpty (json);
+            Assert.AreEqual (SERIALIZED_JSON, json);
+        }
+
+        [Test]
+        public void SerializeToFileWithIndentation()
+        {
+            var obj = new TestObject ();
+
+            var file = new FilePath ("./serialized.json");
+
+            context.CakeContext.SerializeJsonToFile (file, obj, Formatting.Indented);
+
+            var json = System.IO.File.ReadAllText (file.MakeAbsolute (context.CakeContext.Environment).FullPath);
+
+            Assert.IsNotEmpty (json);
+            Assert.AreEqual (SERIALIZED_JSON_INDENTED, json);
         }
 
         [Test]

--- a/Cake.Json.Tests/test_indented.json
+++ b/Cake.Json.Tests/test_indented.json
@@ -1,0 +1,27 @@
+﻿{
+  "Name": "Testing",
+  "Items": [ "One", "Two", "Three" ],
+  "KeysAndValues": {
+    "Key": "Value",
+    "AnotherKey": "AnotherValue",
+    "Such": "Wow"
+  },
+  "Nested": {
+    "Id": 0,
+    "Value": 7.3
+  },
+  "Multiples": [
+    {
+      "Id": 1,
+      "Value": 14.6
+    },
+    {
+      "Id": 2,
+      "Value": 29.2
+    },
+    {
+      "Id": 3,
+      "Value": 58.4
+    }
+  ]
+}

--- a/Cake.Json/Cake.Json.csproj
+++ b/Cake.Json/Cake.Json.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,6 +38,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Formatting.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="JsonAliases.cs" />
     <Compile Include="Namespaces.cs" />

--- a/Cake.Json/Formatting.cs
+++ b/Cake.Json/Formatting.cs
@@ -1,0 +1,18 @@
+﻿namespace Cake.Json
+{
+    /// <summary>
+    /// Controls how the serialized json will be formatted
+    /// </summary>
+    /// <remarks>This enum maps 1-to-1 to <code>Newtonsoft.Json.Formatting</code></remarks>
+    public enum Formatting
+    {
+        /// <summary>
+        /// Create as compact JSON as possible
+        /// </summary>
+        None,
+        /// <summary>
+        /// Pretty-print JSON for human readability
+        /// </summary>
+        Indented
+    }
+}

--- a/Cake.Json/JsonAliases.cs
+++ b/Cake.Json/JsonAliases.cs
@@ -49,12 +49,18 @@ namespace Cake.Json
         /// <param name="context">The context.</param>
         /// <param name="filename">The filename to serialize to.</param>
         /// <param name="instance">The object to serialize.</param>
+        /// <param name="formatting">Whether to pretty-print the JSON output.</param>
         /// <typeparam name="T">The type of object to serialize.</typeparam>
         [CakeMethodAlias]
-        public static void SerializeJsonToFile<T> (this ICakeContext context, FilePath filename, T instance)
+        public static void SerializeJsonToFile<T> (this ICakeContext context, FilePath filename, T instance, Formatting formatting = Formatting.None)
         {
             File.WriteAllText (filename.MakeAbsolute (context.Environment).FullPath,
-                Newtonsoft.Json.JsonConvert.SerializeObject (instance));
+                Newtonsoft.Json.JsonConvert.SerializeObject (instance, new JsonSerializerSettings
+                {
+                    Formatting = formatting == Formatting.Indented
+                    ? Newtonsoft.Json.Formatting.Indented
+                    : Newtonsoft.Json.Formatting.None
+                }));
         }
 
         /// <summary>
@@ -63,23 +69,10 @@ namespace Cake.Json
         /// <returns>The JSON string.</returns>
         /// <param name="context">The context.</param>
         /// <param name="instance">The object to serialize.</param>
+        /// <param name="formatting">Whether to pretty-print the JSON output.</param>
         /// <typeparam name="T">The type of object to serialize.</typeparam>
         [CakeMethodAlias]
-        public static string SerializeJson<T> (this ICakeContext context, T instance)
-        {
-            return Newtonsoft.Json.JsonConvert.SerializeObject (instance);
-        }
-
-        /// <summary>
-        /// Serializes an object to a JSON string, with or without pretty formatting.
-        /// </summary>
-        /// <returns>The JSON string.</returns>
-        /// <param name="context">The context.</param>
-        /// <param name="instance">The object to serialize.</param>
-        /// <param name="formatting">Whether to pretty-print the JSON string or not.</param>
-        /// <typeparam name="T">The type of object to serialize.</typeparam>
-        [CakeMethodAlias]
-        public static string SerializeJson<T>(this ICakeContext context, T instance, Formatting formatting)
+        public static string SerializeJson<T> (this ICakeContext context, T instance, Formatting formatting = Formatting.None)
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject (instance, new JsonSerializerSettings
             {
@@ -88,7 +81,6 @@ namespace Cake.Json
                     : Newtonsoft.Json.Formatting.None
             });
         }
-
 
         /// <summary>
         /// Parses the JSON into a JObject.

--- a/Cake.Json/JsonAliases.cs
+++ b/Cake.Json/JsonAliases.cs
@@ -4,6 +4,7 @@ using Cake.Core.IO;
 using Cake.Core;
 using System.IO;
 using System.Text;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Cake.Json
@@ -67,6 +68,25 @@ namespace Cake.Json
         public static string SerializeJson<T> (this ICakeContext context, T instance)
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject (instance);
+        }
+
+        /// <summary>
+        /// Serializes an object to a JSON string, with or without pretty formatting.
+        /// </summary>
+        /// <returns>The JSON string.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="instance">The object to serialize.</param>
+        /// <param name="formatting">Whether to pretty-print the JSON string or not.</param>
+        /// <typeparam name="T">The type of object to serialize.</typeparam>
+        [CakeMethodAlias]
+        public static string SerializeJson<T>(this ICakeContext context, T instance, Formatting formatting)
+        {
+            return Newtonsoft.Json.JsonConvert.SerializeObject (instance, new JsonSerializerSettings
+            {
+                Formatting = formatting == Formatting.Indented
+                    ? Newtonsoft.Json.Formatting.Indented
+                    : Newtonsoft.Json.Formatting.None
+            });
         }
 
 


### PR DESCRIPTION
This allows for something like this:

```
#addin Cake.Json

SerializeJson(obj, Formatting.Indented);
```

to get a pretty-printed JSON string instead of the default compact.
