### PR TITLE
(GH-12) Embed referenced assemblies in Cake addin assembly

### DIFF
--- a/Cake.Json.nuspec
+++ b/Cake.Json.nuspec
@@ -15,16 +15,9 @@
       <copyright>Copyright (c) Redth 2015</copyright>
       <releaseNotes>Initial Release</releaseNotes>
       <tags>Cake Script Build JSON</tags>
-
-      <dependencies>
-         <dependency id="Newtonsoft.Json" version="7.0.1" />
-      </dependencies>
    </metadata>
-
    <files>
       <file src="./Cake.Json/bin/Release/Cake.Json.dll" target="lib/net45" />
       <file src="./Cake.Json/bin/Release/Cake.Json.xml" target="lib/net45" />
-      <file src="./packages/Newtonsoft.Json.7.0.1/lib/net45/Newtonsoft.Json.dll" target="lib/net45" /> 
-      <file src="./packages/Newtonsoft.Json.7.0.1/lib/net45/Newtonsoft.Json.xml" target="lib/net45" />      
    </files>
 </package>

--- a/Cake.Json/Cake.Json.csproj
+++ b/Cake.Json/Cake.Json.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>Cake.Json</RootNamespace>
     <AssemblyName>Cake.Json</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,4 +49,14 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="FodyWeavers.xml" />
+  </ItemGroup>
+  <Import Project="..\packages\Fody.2.0.8\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.2.0.8\build\dotnet\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.2.0.8\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.8\build\dotnet\Fody.targets'))" />
+  </Target>
 </Project>

--- a/Cake.Json/FodyWeavers.xml
+++ b/Cake.Json/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <Costura />
+</Weavers>

--- a/Cake.Json/packages.config
+++ b/Cake.Json/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Costura.Fody" version="1.4.1" targetFramework="net45" developmentDependency="true" />
+  <package id="Fody" version="2.0.8" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This embeds the `Newtonsoft.Json` assembly in the `Cake.Json` assembly, allowing the addin to be used in scripts or together with addins which already have a differnt version of JSON.NET loaded.

Fixes #12
Fixes #9 