### PR TITLE
Add json.cake exercise script (Group 6 follow-up to #155)

### DIFF
--- a/json.cake
+++ b/json.cake
@@ -1,0 +1,148 @@
+#reference "BuildArtifacts/temp/_PublishedLibraries/Cake.Json/net7.0/Cake.Json.dll"
+
+using Newtonsoft.Json.Linq;
+
+// Self-contained exercise of Cake.Json aliases against a temp working
+// directory. Each task asserts the expected outcome and throws on
+// mismatch — the script fails (non-zero exit) if any alias misbehaves.
+
+void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}
+
+public class Pet
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+}
+
+var workDir = Directory("./BuildArtifacts/temp/test-json");
+var sampleFile = workDir + File("sample.json");
+var roundtripFile = workDir + File("roundtrip.json");
+var prettyFile = workDir + File("pretty.json");
+
+Task("Default")
+    .IsDependentOn("Setup")
+    .IsDependentOn("Serialize-To-String")
+    .IsDependentOn("Deserialize-From-String")
+    .IsDependentOn("Roundtrip-File")
+    .IsDependentOn("Pretty-Format")
+    .IsDependentOn("Parse-JObject-From-String")
+    .IsDependentOn("Parse-JObject-From-File")
+    .IsDependentOn("Cleanup");
+
+Task("Setup")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    EnsureDirectoryExists(workDir);
+    System.IO.File.WriteAllText(
+        sampleFile.Path.FullPath,
+        "{ \"Name\": \"Whiskers\", \"Age\": 7 }");
+    Information("Setup complete.");
+});
+
+Task("Serialize-To-String")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = new Pet { Name = "Rex", Age = 3 };
+    var json = SerializeJson(pet);
+
+    AssertThat(json.Contains("\"Name\":\"Rex\""), "SerializeJson: missing Name");
+    AssertThat(json.Contains("\"Age\":3"), "SerializeJson: missing Age");
+    Information("SerializeJson OK ({0})", json);
+});
+
+Task("Deserialize-From-String")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = DeserializeJson<Pet>("{ \"Name\": \"Mittens\", \"Age\": 5 }");
+
+    AssertThat(pet.Name == "Mittens", "DeserializeJson: Name mismatch");
+    AssertThat(pet.Age == 5, "DeserializeJson: Age mismatch");
+    Information("DeserializeJson OK ({0}, age {1})", pet.Name, pet.Age);
+});
+
+Task("Roundtrip-File")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = new Pet { Name = "Buddy", Age = 2 };
+    SerializeJsonToFile(roundtripFile, pet);
+    AssertThat(System.IO.File.Exists(roundtripFile.Path.FullPath),
+        "SerializeJsonToFile: file not created");
+
+    var loaded = DeserializeJsonFromFile<Pet>(roundtripFile);
+    AssertThat(loaded.Name == "Buddy", "Roundtrip: Name mismatch");
+    AssertThat(loaded.Age == 2, "Roundtrip: Age mismatch");
+    Information("SerializeJsonToFile + DeserializeJsonFromFile OK ({0}, age {1})", loaded.Name, loaded.Age);
+});
+
+Task("Pretty-Format")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = new Pet { Name = "Fluffy", Age = 4 };
+
+    var pretty = SerializeJsonPretty(pet);
+    AssertThat(pretty.Contains("\n") || pretty.Contains("\r\n"),
+        "SerializeJsonPretty: missing newlines (expected indented output)");
+    Information("SerializeJsonPretty OK ({0} chars)", pretty.Length);
+
+    SerializeJsonToPrettyFile(prettyFile, pet);
+    var diskContent = System.IO.File.ReadAllText(prettyFile.Path.FullPath);
+    AssertThat(diskContent.Contains("\n") || diskContent.Contains("\r\n"),
+        "SerializeJsonToPrettyFile: missing newlines on disk");
+    Information("SerializeJsonToPrettyFile OK ({0} chars on disk)", diskContent.Length);
+});
+
+Task("Parse-JObject-From-String")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var jobj = ParseJson("{ \"Name\": \"Spot\", \"Age\": 8 }");
+
+    AssertThat((string)jobj["Name"] == "Spot", "ParseJson: Name mismatch");
+    AssertThat((int)jobj["Age"] == 8, "ParseJson: Age mismatch");
+    Information("ParseJson OK ({0}, age {1})", jobj["Name"], jobj["Age"]);
+});
+
+Task("Parse-JObject-From-File")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var jobj = ParseJsonFromFile(sampleFile);
+
+    AssertThat((string)jobj["Name"] == "Whiskers", "ParseJsonFromFile: Name mismatch");
+    AssertThat((int)jobj["Age"] == 7, "ParseJsonFromFile: Age mismatch");
+    Information("ParseJsonFromFile OK ({0}, age {1})", jobj["Name"], jobj["Age"]);
+});
+
+Task("Cleanup")
+    .IsDependentOn("Serialize-To-String")
+    .IsDependentOn("Deserialize-From-String")
+    .IsDependentOn("Roundtrip-File")
+    .IsDependentOn("Pretty-Format")
+    .IsDependentOn("Parse-JObject-From-String")
+    .IsDependentOn("Parse-JObject-From-File")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    Information("Cleanup complete.");
+});
+
+RunTarget("Default");


### PR DESCRIPTION
## Summary

Adds a self-contained `json.cake` at the repo root that exercises every alias the addin exposes:

- `SerializeJson` / `SerializeJsonPretty` (string output)
- `SerializeJsonToFile` / `SerializeJsonToPrettyFile` (file output)
- `DeserializeJson` / `DeserializeJsonFromFile` (`T` round-trip)
- `ParseJson` / `ParseJsonFromFile` (`JObject` round-trip)

Each task asserts the expected outcome and throws on mismatch — the script fails (non-zero exit) if any alias misbehaves. Modelled on [`Cake.FileHelpers/test.cake`](https://github.com/cake-contrib/Cake.FileHelpers/blob/develop/test.cake) (canonical shape).

This was missed from [#155](https://github.com/cake-contrib/Cake.Json/pull/155) — the workspace-level addin audit had Cake.Json on its "Group 6 (Add exercise script)" list and the rule going forward is to bundle Group 6 into the matching baseline PR. Captured as a memory rule in the workspace so future addins don't repeat the miss.

## Test plan

- [ ] Reviewer runs `json.cake` against a freshly built `Cake.Json.dll` and confirms it exits 0