### PR TITLE
(#172) Cake 3 catch-up + demo/{script,frosting} retrofit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,24 @@ jobs:
           verbosity: Normal
           cake-version: tool-manifest
 
+      # The demo/ folders exercise the just-built addin DLL under
+      # Cake-major-matching cake.tool / Cake.Frosting versions. They
+      # run in their OWN tool/package context (independent of
+      # recipe.cake's cake.tool, which is constrained by Cake.Recipe's
+      # runtime). Both demos consume the addin from
+      # BuildArtifacts/temp/_PublishedLibraries/ populated by
+      # DotNetCore-Pack. demo/sdk joins later, in the v11.0.0 catch-up.
+
+      - name: Run demo/script
+        if: success()
+        shell: pwsh
+        run: ./demo/script/build.ps1
+
+      - name: Run demo/frosting
+        if: success()
+        shell: pwsh
+        run: ./demo/frosting/build.ps1
+
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:

--- a/demo/frosting/build.ps1
+++ b/demo/frosting/build.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet run --project build/Build.csproj -- @args
+exit $LASTEXITCODE;

--- a/demo/frosting/build.sh
+++ b/demo/frosting/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet run --project build/Build.csproj -- "$@"

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Cake.Json">
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net6.0\Cake.Json.dll</HintPath>
+    </Reference>
+    <PackageReference Include="Cake.Frosting" Version="3.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -10,6 +10,6 @@
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net6.0\Cake.Json.dll</HintPath>
     </Reference>
     <PackageReference Include="Cake.Frosting" Version="3.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/demo/frosting/build/BuildContext.cs
+++ b/demo/frosting/build/BuildContext.cs
@@ -1,0 +1,22 @@
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Frosting;
+
+namespace Build
+{
+    public class BuildContext : FrostingContext
+    {
+        public DirectoryPath WorkDir { get; } = "./BuildArtifacts/temp/test-json-frosting";
+
+        public FilePath SampleFile => WorkDir.CombineWithFilePath("sample.json");
+
+        public FilePath RoundtripFile => WorkDir.CombineWithFilePath("roundtrip.json");
+
+        public FilePath PrettyFile => WorkDir.CombineWithFilePath("pretty.json");
+
+        public BuildContext(ICakeContext context)
+            : base(context)
+        {
+        }
+    }
+}

--- a/demo/frosting/build/DefaultTask.cs
+++ b/demo/frosting/build/DefaultTask.cs
@@ -1,0 +1,11 @@
+using Build.Tasks;
+using Cake.Frosting;
+
+namespace Build
+{
+    [TaskName("Default")]
+    [IsDependentOn(typeof(CleanupTask))]
+    public sealed class DefaultTask : FrostingTask
+    {
+    }
+}

--- a/demo/frosting/build/Pet.cs
+++ b/demo/frosting/build/Pet.cs
@@ -1,0 +1,9 @@
+namespace Build
+{
+    public class Pet
+    {
+        public string Name { get; set; }
+
+        public int Age { get; set; }
+    }
+}

--- a/demo/frosting/build/Program.cs
+++ b/demo/frosting/build/Program.cs
@@ -1,0 +1,14 @@
+using Cake.Frosting;
+
+namespace Build
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            return new CakeHost()
+                .UseContext<BuildContext>()
+                .Run(args);
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/CleanupTask.cs
+++ b/demo/frosting/build/Tasks/CleanupTask.cs
@@ -1,0 +1,28 @@
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("Cleanup")]
+    [IsDependentOn(typeof(SerializeToStringTask))]
+    [IsDependentOn(typeof(DeserializeFromStringTask))]
+    [IsDependentOn(typeof(RoundtripFileTask))]
+    [IsDependentOn(typeof(PrettyFormatTask))]
+    [IsDependentOn(typeof(ParseFromStringTask))]
+    [IsDependentOn(typeof(ParseFromFileTask))]
+    public sealed class CleanupTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            if (context.DirectoryExists(context.WorkDir))
+            {
+                context.DeleteDirectory(
+                    context.WorkDir,
+                    new DeleteDirectorySettings { Recursive = true });
+            }
+
+            context.Information("Cleanup complete.");
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/DeserializeFromStringTask.cs
+++ b/demo/frosting/build/Tasks/DeserializeFromStringTask.cs
@@ -1,0 +1,29 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Json;
+
+namespace Build.Tasks
+{
+    [TaskName("Deserialize-From-String")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class DeserializeFromStringTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var pet = context.DeserializeJson<Pet>("{ \"Name\": \"Mittens\", \"Age\": 5 }");
+
+            AssertThat(pet.Name == "Mittens", "DeserializeJson: Name mismatch");
+            AssertThat(pet.Age == 5, "DeserializeJson: Age mismatch");
+            context.Information("DeserializeJson OK ({0}, age {1})", pet.Name, pet.Age);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/ParseFromFileTask.cs
+++ b/demo/frosting/build/Tasks/ParseFromFileTask.cs
@@ -1,0 +1,29 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Json;
+
+namespace Build.Tasks
+{
+    [TaskName("Parse-JObject-From-File")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class ParseFromFileTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var jobj = context.ParseJsonFromFile(context.SampleFile);
+
+            AssertThat((string)jobj["Name"] == "Whiskers", "ParseJsonFromFile: Name mismatch");
+            AssertThat((int)jobj["Age"] == 7, "ParseJsonFromFile: Age mismatch");
+            context.Information("ParseJsonFromFile OK ({0}, age {1})", jobj["Name"], jobj["Age"]);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/ParseFromStringTask.cs
+++ b/demo/frosting/build/Tasks/ParseFromStringTask.cs
@@ -1,0 +1,29 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Json;
+
+namespace Build.Tasks
+{
+    [TaskName("Parse-JObject-From-String")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class ParseFromStringTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var jobj = context.ParseJson("{ \"Name\": \"Spot\", \"Age\": 8 }");
+
+            AssertThat((string)jobj["Name"] == "Spot", "ParseJson: Name mismatch");
+            AssertThat((int)jobj["Age"] == 8, "ParseJson: Age mismatch");
+            context.Information("ParseJson OK ({0}, age {1})", jobj["Name"], jobj["Age"]);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/PrettyFormatTask.cs
+++ b/demo/frosting/build/Tasks/PrettyFormatTask.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Cake.Common.Diagnostics;
+using Cake.Common.IO;
 using Cake.Frosting;
 using Cake.Json;
 

--- a/demo/frosting/build/Tasks/PrettyFormatTask.cs
+++ b/demo/frosting/build/Tasks/PrettyFormatTask.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Json;
+
+namespace Build.Tasks
+{
+    [TaskName("Pretty-Format")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class PrettyFormatTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var pet = new Pet { Name = "Fluffy", Age = 4 };
+
+            var pretty = context.SerializeJsonPretty(pet);
+            AssertThat(
+                pretty.Contains("\n") || pretty.Contains("\r\n"),
+                "SerializeJsonPretty: missing newlines (expected indented output)");
+            context.Information("SerializeJsonPretty OK ({0} chars)", pretty.Length);
+
+            context.SerializeJsonToPrettyFile(context.PrettyFile, pet);
+            var diskContent = File.ReadAllText(context.MakeAbsolute(context.PrettyFile).FullPath);
+            AssertThat(
+                diskContent.Contains("\n") || diskContent.Contains("\r\n"),
+                "SerializeJsonToPrettyFile: missing newlines on disk");
+            context.Information("SerializeJsonToPrettyFile OK ({0} chars on disk)", diskContent.Length);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/RoundtripFileTask.cs
+++ b/demo/frosting/build/Tasks/RoundtripFileTask.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Json;
+
+namespace Build.Tasks
+{
+    [TaskName("Roundtrip-File")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class RoundtripFileTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var pet = new Pet { Name = "Buddy", Age = 2 };
+            context.SerializeJsonToFile(context.RoundtripFile, pet);
+            AssertThat(
+                File.Exists(context.MakeAbsolute(context.RoundtripFile).FullPath),
+                "SerializeJsonToFile: file not created");
+
+            var loaded = context.DeserializeJsonFromFile<Pet>(context.RoundtripFile);
+            AssertThat(loaded.Name == "Buddy", "Roundtrip: Name mismatch");
+            AssertThat(loaded.Age == 2, "Roundtrip: Age mismatch");
+            context.Information(
+                "SerializeJsonToFile + DeserializeJsonFromFile OK ({0}, age {1})",
+                loaded.Name,
+                loaded.Age);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/RoundtripFileTask.cs
+++ b/demo/frosting/build/Tasks/RoundtripFileTask.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Cake.Common.Diagnostics;
+using Cake.Common.IO;
 using Cake.Frosting;
 using Cake.Json;
 

--- a/demo/frosting/build/Tasks/SerializeToStringTask.cs
+++ b/demo/frosting/build/Tasks/SerializeToStringTask.cs
@@ -1,0 +1,30 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Json;
+
+namespace Build.Tasks
+{
+    [TaskName("Serialize-To-String")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class SerializeToStringTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var pet = new Pet { Name = "Rex", Age = 3 };
+            var json = context.SerializeJson(pet);
+
+            AssertThat(json.Contains("\"Name\":\"Rex\""), "SerializeJson: missing Name");
+            AssertThat(json.Contains("\"Age\":3"), "SerializeJson: missing Age");
+            context.Information("SerializeJson OK ({0})", json);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/SetupTask.cs
+++ b/demo/frosting/build/Tasks/SetupTask.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("Setup")]
+    public sealed class SetupTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            if (context.DirectoryExists(context.WorkDir))
+            {
+                context.DeleteDirectory(
+                    context.WorkDir,
+                    new DeleteDirectorySettings { Recursive = true });
+            }
+
+            context.EnsureDirectoryExists(context.WorkDir);
+
+            File.WriteAllText(
+                context.MakeAbsolute(context.SampleFile).FullPath,
+                "{ \"Name\": \"Whiskers\", \"Age\": 7 }");
+
+            context.Information("Setup complete.");
+        }
+    }
+}

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+        "cake.tool": {
+            "version": "3.2.0",
+            "commands": [
+                "dotnet-cake"
+            ]
+        }
+    }
+}

--- a/demo/script/.gitignore
+++ b/demo/script/.gitignore
@@ -1,0 +1,5 @@
+tools/
+!tools/packages.config
+output/
+.vscode/
+_work/

--- a/demo/script/build.ps1
+++ b/demo/script/build.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet tool restore
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet cake json.cake @args
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/demo/script/build.sh
+++ b/demo/script/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet tool restore
+
+dotnet cake json.cake "$@"

--- a/demo/script/json.cake
+++ b/demo/script/json.cake
@@ -1,4 +1,4 @@
-#reference "BuildArtifacts/temp/_PublishedLibraries/Cake.Json/net7.0/Cake.Json.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Json/net6.0/Cake.Json.dll"
 
 using Newtonsoft.Json.Linq;
 
@@ -20,7 +20,7 @@ public class Pet
     public int Age { get; set; }
 }
 
-var workDir = Directory("./BuildArtifacts/temp/test-json");
+var workDir = Directory("./_work");
 var sampleFile = workDir + File("sample.json");
 var roundtripFile = workDir + File("roundtrip.json");
 var prettyFile = workDir + File("pretty.json");

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.100",
+      "version": "8.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/src/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/src/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Cake.Json/Cake.Json.csproj
+++ b/src/Cake.Json/Cake.Json.csproj
@@ -17,7 +17,7 @@
     <Title>Cake.Json</Title>
     <Summary>JSON Serialization and manipulation addon for cake build.</Summary>
     <Description>Cake Build addon for JSON Serialization and manipulation.</Description>
-    <PackageTags>cake;script;build;cake-addin;addin;cake-build</PackageTags>
+    <PackageTags>cake;cake-build;cake-addin;addin;script;build;json;newtonsoft;serialization</PackageTags>
     <Authors>Redth</Authors>
     <Owners>Redth, cake-contrib</Owners>
     <RepositoryUrl>https://github.com/cake-contrib/Cake.Json.git</RepositoryUrl>


### PR DESCRIPTION
Closes #172.

The first workspace-driven release of Cake.Json. `develop` already carried the Cake 3 bump (`Cake.Core` / `Cake.Common` 3.0.0, addin TFMs `net6.0;net7.0`) so this PR folds baseline-retrofit hygiene into the Cake 3 version stamp — mirroring the shape of the Cake.FileHelpers v8.0.0 catch-up.

## What's in it

1. **Canonicalise `PackageTags`** — reorder to the workspace-canonical `cake;cake-build;cake-addin;addin;script;build` prefix + json-specific tail tags (`json;newtonsoft;serialization`).
2. **Move `json.cake` to `demo/script/`** — the root-level exercise script added in #159 relocates under `demo/script/json.cake` with the canonical `build.ps1` / `build.sh` / `.config/dotnet-tools.json` wrappers pinning `cake.tool` 3.2.0 (latest of the Cake 3 major). `#reference` retargeted to the `net6.0` published DLL.
3. **Add `demo/frosting/`** — new Cake.Frosting 3.2.0 consumer that end-to-end exercises every alias surfaced by Cake.Json: `SerializeJson`, `DeserializeJson<T>`, `SerializeJsonToFile` + `DeserializeJsonFromFile<T>`, `SerializeJsonPretty` + `SerializeJsonToPrettyFile`, `ParseJson`, `ParseJsonFromFile`. Task graph mirrors `demo/script/json.cake`.
4. **Wire demos into `build.yml`** — two new CI steps (`Run demo/script` and `Run demo/frosting`) after the recipe build, both using `pwsh` so they run identically on `windows-2025` and `ubuntu-24.04`.
5. **`global.json` SDK 7.0.100 → 8.0.100** — SDK 8 covers both `net6.0` and `net7.0` cleanly (matches Cake.Gulp / Cake.ReSharperReports / Cake.Eazfuscator.Net at their v3.0.0 tags).
6. **Narrow tests project to single-TFM `net6.0`** — tests target the lowest supported addin TFM per the workspace tests-TFM rotation convention. Cake.Core / Cake.Testing stay at 3.0.0.
7. **Fix demo/frosting compile against Cake.Frosting 3.2.0** — small fix-up caught by the local demo run: bump demo's `Newtonsoft.Json` to 13.0.3 to satisfy the transitive floor from Cake.NuGet, and add `using Cake.Common.IO;` to two tasks that use `MakeAbsolute`.

No source edits to the addin itself. Cake.Core / Cake.Common stay pinned at 3.0.0.

## Verified locally

- `./build.ps1 --target=DotNetCore-Pack` — exit 0 (0 errors, pre-existing StyleCop noise unchanged)
- `./demo/script/build.ps1` — exit 0 (all 8 script tasks pass)
- `./demo/frosting/build.ps1` — exit 0 (all 8 Frosting tasks pass)

## Follow-ups (not in this PR)

Per the strict per-Cake-major cadence, the rest of the arc will land as separate PRs:

- v9.0.0 — Cake 4 catch-up
- v10.0.0 — Cake 5 catch-up
- v11.0.0 — Cake 6 catch-up (adds `demo/sdk/`)