### PR TITLE
(#174) Cake 4 catch-up

### DIFF
--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,7 +9,7 @@
     <Reference Include="Cake.Json">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net6.0\Cake.Json.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="3.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "3.2.0",
+            "version": "4.2.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/src/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/src/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="3.0.0" />
-    <PackageReference Include="Cake.Testing" Version="3.0.0" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" />
+    <PackageReference Include="Cake.Testing" Version="4.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Cake.Json/Cake.Json.csproj
+++ b/src/Cake.Json/Cake.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">


### PR DESCRIPTION
Closes #174.

Second workspace-driven release. Standard per-Cake-major shape: bump the addin's Cake.Core / Cake.Common contract from 3.0.0 to 4.0.0, gain the `net8.0` TFM alongside the existing `net6.0` + `net7.0`, and rotate the demo/{script,frosting} tooling pins to the latest of the Cake 4 major.

## What's in it

1. **Cake.Core / Cake.Common 3.0.0 → 4.0.0** and addin TFMs `net6.0;net7.0` → `net6.0;net7.0;net8.0` — Cake 4 adds net8.0 alongside the existing floors.
2. **Tests project Cake.Core / Cake.Testing 3.0.0 → 4.0.0** — tests TFM stays at `net6.0` (Cake 4 keeps net6.0 as the supported floor).
3. **`demo/script/.config/dotnet-tools.json` cake.tool 3.2.0 → 4.2.0** (latest of Cake 4 major).
4. **`demo/frosting/build/Build.csproj` Cake.Frosting 3.2.0 → 4.2.0** (latest of Cake 4 major). TFM + HintPath stay at `net6.0`.

No source edits — grep of `src/Cake.Json/*.cs` for `ArgumentNullException` returned zero throws, so the `ArgumentNullException.ThrowIfNull` modernisation is a no-op for this addin. `global.json` stays at `8.0.100` (SDK 8 already covers all three addin TFMs after the v8.0.0 bump).

## Verified locally

- `./build.ps1 --target=DotNetCore-Pack` — exit 0 (produces `Cake.Json.8.1.0-issue-174-cake-40001.nupkg`)
- `./demo/script/build.ps1` — exit 0 (all 8 script tasks pass)
- `./demo/frosting/build.ps1` — exit 0 (all 8 Frosting tasks pass)

## Follow-ups (not in this PR)

Per the strict per-Cake-major cadence:

- v10.0.0 — Cake 5 catch-up
- v11.0.0 — Cake 6 catch-up (adds `demo/sdk/`)