### PR TITLE
(#176) Cake 5 catch-up

### DIFF
--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -10,6 +10,6 @@
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net8.0\Cake.Json.dll</HintPath>
     </Reference>
     <PackageReference Include="Cake.Frosting" Version="5.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Json">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net6.0\Cake.Json.dll</HintPath>
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net8.0\Cake.Json.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "4.2.0",
+            "version": "5.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/script/json.cake
+++ b/demo/script/json.cake
@@ -1,4 +1,4 @@
-#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Json/net6.0/Cake.Json.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Json/net8.0/Cake.Json.dll"
 
 using Newtonsoft.Json.Linq;
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/src/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/src/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" />
-    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" />
+    <PackageReference Include="Cake.Testing" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Cake.Json/Cake.Json.csproj
+++ b/src/Cake.Json/Cake.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">


### PR DESCRIPTION
Closes #176.

Third workspace-driven release. **TFM-dropping arc**: Cake 5 drops `net6.0` and `net7.0` from the addin's supported floor and adds `net9.0`, so the addin ships against `net8.0` + `net9.0` only.

## What's in it

1. **Cake.Core / Cake.Common 4.0.0 → 5.0.0** and addin TFMs `net6.0;net7.0;net8.0` → `net8.0;net9.0`.
2. **Tests project Cake.Core / Cake.Testing 4.0.0 → 5.0.0**; tests TFM `net6.0` → `net8.0` per the tests-TFM rotation.
3. **`demo/script/.config/dotnet-tools.json` cake.tool 4.2.0 → 5.1.0** (latest of Cake 5 major).
4. **`demo/frosting/build/Build.csproj` Cake.Frosting 4.2.0 → 5.1.0**; TFM + HintPath `net6.0` → `net8.0`.
5. **`demo/script/json.cake` `#reference` `net6.0` → `net8.0`** — parallel to the demo/frosting HintPath rotation, per workspace convention. TFM-dropping arcs are exactly where these two files have to move together.
6. **`global.json` SDK 8.0.100 → 9.0.100** — SDK 9 covers the new net8.0 + net9.0 range cleanly.
7. **Fix-up**: demo/frosting `Newtonsoft.Json` 13.0.3 → 13.0.4, caught by the local demo run — Cake.Frosting 5.1.0 pulls Newtonsoft.Json (>= 13.0.4) transitively and the old pin tripped NU1605 as a downgrade. Same shape as the v8.0.0 fix-up.

No source edits to the addin itself.

## Verified locally

- `./build.ps1 --target=DotNetCore-Pack` — exit 0 (`Cake.Json.9.1.0-issue-176-cake-50001.nupkg`), `_PublishedLibraries` populated with `net8.0/` + `net9.0/` only.
- `./demo/script/build.ps1` — exit 0 (all 8 script tasks pass).
- `./demo/frosting/build.ps1` — exit 0 (all 8 Frosting tasks pass).

## Follow-up

- v11.0.0 — Cake 6 catch-up (adds `demo/sdk/`)