### PR TITLE
(#178) Cake 6 catch-up + demo/sdk debut

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,12 @@ jobs:
         shell: pwsh
         run: ./demo/frosting/build.ps1
 
+      - name: Run demo/sdk
+        if: success()
+        shell: pwsh
+        working-directory: ./demo/sdk
+        run: dotnet cake.cs
+
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,7 +9,7 @@
     <Reference Include="Cake.Json">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Json\net8.0\Cake.Json.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "5.1.0",
+            "version": "6.2.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/sdk/.gitignore
+++ b/demo/sdk/.gitignore
@@ -1,0 +1,1 @@
+BuildArtifacts/

--- a/demo/sdk/cake.cs
+++ b/demo/sdk/cake.cs
@@ -1,0 +1,165 @@
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk@6.2.0
+#:project ../../src/Cake.Json/Cake.Json.csproj
+
+// Cake SDK consumer demo for Cake.Json. Runs as a file-based .NET
+// program (introduced in .NET 10) using the Cake.Sdk directives.
+// The #:project directive above lets the SDK build the addin from
+// source rather than referencing a published nupkg.
+//
+// To run locally:
+//   cd demo/sdk
+//   dotnet cake.cs
+//
+// Mirrors the alias surface exercised by demo/script/json.cake and
+// demo/frosting/, against a temp working directory under
+// demo/sdk/BuildArtifacts/ (gitignored). Each task asserts the
+// expected outcome and throws on mismatch — the script fails
+// (non-zero exit) if any alias misbehaves.
+
+using Cake.Json;
+using Newtonsoft.Json.Linq;
+
+var workDir = Directory("./BuildArtifacts/temp/test-json-sdk");
+var sampleFile = workDir + File("sample.json");
+var roundtripFile = workDir + File("roundtrip.json");
+var prettyFile = workDir + File("pretty.json");
+
+Task("Default")
+    .IsDependentOn("Setup")
+    .IsDependentOn("Serialize-To-String")
+    .IsDependentOn("Deserialize-From-String")
+    .IsDependentOn("Roundtrip-File")
+    .IsDependentOn("Pretty-Format")
+    .IsDependentOn("Parse-JObject-From-String")
+    .IsDependentOn("Parse-JObject-From-File")
+    .IsDependentOn("Cleanup");
+
+Task("Setup")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    EnsureDirectoryExists(workDir);
+    System.IO.File.WriteAllText(
+        sampleFile.Path.FullPath,
+        "{ \"Name\": \"Whiskers\", \"Age\": 7 }");
+    Information("Setup complete.");
+});
+
+Task("Serialize-To-String")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = new Pet { Name = "Rex", Age = 3 };
+    var json = SerializeJson(pet);
+
+    AssertThat(json.Contains("\"Name\":\"Rex\""), "SerializeJson: missing Name");
+    AssertThat(json.Contains("\"Age\":3"), "SerializeJson: missing Age");
+    Information("SerializeJson OK ({0})", json);
+});
+
+Task("Deserialize-From-String")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = DeserializeJson<Pet>("{ \"Name\": \"Mittens\", \"Age\": 5 }");
+
+    AssertThat(pet.Name == "Mittens", "DeserializeJson: Name mismatch");
+    AssertThat(pet.Age == 5, "DeserializeJson: Age mismatch");
+    Information("DeserializeJson OK ({0}, age {1})", pet.Name, pet.Age);
+});
+
+Task("Roundtrip-File")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = new Pet { Name = "Buddy", Age = 2 };
+    SerializeJsonToFile(roundtripFile, pet);
+    AssertThat(System.IO.File.Exists(roundtripFile.Path.FullPath),
+        "SerializeJsonToFile: file not created");
+
+    var loaded = DeserializeJsonFromFile<Pet>(roundtripFile);
+    AssertThat(loaded.Name == "Buddy", "Roundtrip: Name mismatch");
+    AssertThat(loaded.Age == 2, "Roundtrip: Age mismatch");
+    Information("SerializeJsonToFile + DeserializeJsonFromFile OK ({0}, age {1})", loaded.Name, loaded.Age);
+});
+
+Task("Pretty-Format")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var pet = new Pet { Name = "Fluffy", Age = 4 };
+
+    var pretty = SerializeJsonPretty(pet);
+    AssertThat(pretty.Contains("\n") || pretty.Contains("\r\n"),
+        "SerializeJsonPretty: missing newlines (expected indented output)");
+    Information("SerializeJsonPretty OK ({0} chars)", pretty.Length);
+
+    SerializeJsonToPrettyFile(prettyFile, pet);
+    var diskContent = System.IO.File.ReadAllText(prettyFile.Path.FullPath);
+    AssertThat(diskContent.Contains("\n") || diskContent.Contains("\r\n"),
+        "SerializeJsonToPrettyFile: missing newlines on disk");
+    Information("SerializeJsonToPrettyFile OK ({0} chars on disk)", diskContent.Length);
+});
+
+Task("Parse-JObject-From-String")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var jobj = ParseJson("{ \"Name\": \"Spot\", \"Age\": 8 }");
+
+    AssertThat((string)jobj["Name"] == "Spot", "ParseJson: Name mismatch");
+    AssertThat((int)jobj["Age"] == 8, "ParseJson: Age mismatch");
+    Information("ParseJson OK ({0}, age {1})", jobj["Name"], jobj["Age"]);
+});
+
+Task("Parse-JObject-From-File")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var jobj = ParseJsonFromFile(sampleFile);
+
+    AssertThat((string)jobj["Name"] == "Whiskers", "ParseJsonFromFile: Name mismatch");
+    AssertThat((int)jobj["Age"] == 7, "ParseJsonFromFile: Age mismatch");
+    Information("ParseJsonFromFile OK ({0}, age {1})", jobj["Name"], jobj["Age"]);
+});
+
+Task("Cleanup")
+    .IsDependentOn("Serialize-To-String")
+    .IsDependentOn("Deserialize-From-String")
+    .IsDependentOn("Roundtrip-File")
+    .IsDependentOn("Pretty-Format")
+    .IsDependentOn("Parse-JObject-From-String")
+    .IsDependentOn("Parse-JObject-From-File")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    Information("Cleanup complete.");
+});
+
+RunTarget("Default");
+
+// ----- Helpers (must come AFTER top-level statements per CS8803) -----
+
+static void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}
+
+public class Pet
+{
+    public string Name { get; set; }
+
+    public int Age { get; set; }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.100",
+      "version": "10.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/src/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/src/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" />
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Cake.Json/Cake.Json.csproj
+++ b/src/Cake.Json/Cake.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">


### PR DESCRIPTION
Closes #178.

Fourth (and final) workspace-driven release of Cake.Json. Cake 6 adds `net10.0` to the supported floor and this arc introduces the `demo/sdk/` folder — a file-based .NET 10 program consuming the addin via `Cake.Sdk` 6.2.0 + `#:project` directive. Completes the strict per-Cake-major cadence started at v8.0.0.

## What's in it

1. **Cake.Core / Cake.Common 5.0.0 → 6.0.0** and addin TFMs `net8.0;net9.0` → `net8.0;net9.0;net10.0` (gain net10.0).
2. **Tests project Cake.Core / Cake.Testing 5.0.0 → 6.0.0** — tests TFM stays at `net8.0`.
3. **`demo/script/.config/dotnet-tools.json` cake.tool 5.1.0 → 6.2.0**.
4. **`demo/frosting/build/Build.csproj` Cake.Frosting 5.1.0 → 6.2.0** — Newtonsoft.Json stays at 13.0.4 (Cake.NuGet 6.2.0's transitive floor matches, verified via nuspec lookup at pre-arc audit time).
5. **`global.json` SDK 9.0.100 → 10.0.100** — SDK 10 covers the full net8.0/net9.0/net10.0 range.
6. **NEW `demo/sdk/cake.cs`** with Cake.Sdk 6.2.0 + `#:project ../../src/Cake.Json/Cake.Json.csproj` (builds addin from source). Mirrors the alias surface of demo/script and demo/frosting — Setup writes scratch sample.json, seven exercise tasks + Cleanup, workspace `AssertThat` helper. Public type name audit against Cake.Core clean (only public type is `JsonAliases`, a static class).
7. **`build.yml` gains a `Run demo/sdk` step** — third demo run alongside the existing script + frosting steps.

No source edits to the addin itself.

## Verified locally

- `./build.ps1 --target=DotNetCore-Pack` — exit 0. `_PublishedLibraries` populated with `net8.0/` + `net9.0/` + `net10.0/`.
- `./demo/script/build.ps1` — exit 0 (all 8 script tasks pass).
- `./demo/frosting/build.ps1` — exit 0 (all 8 Frosting tasks pass).
- `dotnet cake.cs` in `demo/sdk/` — exit 0 (all 8 SDK tasks pass, first-run clean).

## Post-arc state

All four workspace-driven Cake.Json releases (v8.0.0, v9.0.0, v10.0.0, v11.0.0) will be live on NuGet.org. Renovate takes over ongoing dep housekeeping. Cake.Recipe / Chocolatey.Cake.Recipe upstream will pick up the new addin range via AddinDiscoverer's auto-bump PR once the tag ships.